### PR TITLE
Fix switch, add default case

### DIFF
--- a/ucdn.c
+++ b/ucdn.c
@@ -231,9 +231,10 @@ int ucdn_get_resolved_linebreak_class(uint32_t code)
 
     case UCDN_LINEBREAK_CLASS_NL:
         return UCDN_LINEBREAK_CLASS_BK;
-    }
 
-    return record->linebreak_class;
+    default:
+        return record->linebreak_class;
+    }
 }
 
 uint32_t ucdn_mirror(uint32_t code)


### PR DESCRIPTION
I had the following warning while using ucdn in my code:
```
ucdn/ucdn.c: In function 'ucdn_get_resolved_linebreak_class':
ucdn/ucdn.c:213:5: error: switch missing default case [-Werror=switch-default]
     switch (record->linebreak_class)
```
I added a default case.